### PR TITLE
#33: jsonschema_metrics.py, correctly indent 'return'

### DIFF
--- a/package/schema/jsonschema_metrics.py
+++ b/package/schema/jsonschema_metrics.py
@@ -70,4 +70,4 @@ def jsonschema_metrics():
       },
     },
   }
-return schema
+  return schema


### PR DESCRIPTION
Resolves #33.
